### PR TITLE
Changed OpenStreetMap proxy URL

### DIFF
--- a/js/wms-gs-2_0_0.js
+++ b/js/wms-gs-2_0_0.js
@@ -90,7 +90,7 @@ var GuifiLayer = function(map, url, layers) {
 var openStreet = new google.maps.ImageMapType({
       getTileUrl: function(ll, z) {
               var X = ll.x % (1 << z);  // wrap
-              return "http://alzina.act.uji.es/tiles/" + z + "/" + X + "/" + ll.y + ".png";
+              return "http://alzina.act.uji.es/" + z + "/" + X + "/" + ll.y + ".png";
       },
       tileSize: new google.maps.Size(256, 256),
       isPng: true,


### PR DESCRIPTION
The server infrastructure was changed to being just a reverse proxy with Squid, rather than a full OSM renderer. In two years nobody cared to make a custom OSM style for Guifi.net anyway. So we lose the feature of making our own styles, but we gain simplicity, less server load, and we get automatic full-world OSM updates. To simplify Squid configuration we need to make a slight change in the URL: from "http://alzina.act.uji.es/tiles/" to "http://alzina.act.uji.es/", so no URL rewrites are necessary in Squid.

Instructions taken from here: http://wiki.openstreetmap.org/wiki/Tile_Proxy/squid
