### PR TITLE
[guifi-radios] Adapt the model and firmware selection in the device form to Drupal 7

### DIFF
--- a/guifi_ahah.inc.php
+++ b/guifi_ahah.inc.php
@@ -127,7 +127,7 @@ function guifi_ahah_select_service(){
                                 ':string4' => '%' . db_like($string) .'%',
                                 )
                  );
-    
+
   $c = 0;
   while (($value = $qry->fetchAssoc()) and ($c < 50)) {
     $c++;
@@ -268,14 +268,14 @@ function guifi_ahah_select_device_interfacename($delete = false) {
   $device = explode('-',$_POST['ipv4'][$ids[0]]['subnet'][$ids[1]]['did']);
 
   guifi_log(GUIFILOG_TRACE,sprintf('guifi_ahah_select_device_interfacename (ids=%s did=%d)',arg(3),$device[0]));
-  
+
   $device_interfaces = guifi_get_device_allinterfaces($device[0]);
 
   $rIpv4 = $_POST['ipv4'][$ids[0]]['subnet'][$ids[1]];
 
   if ($cache) {
     $form = $cache->data;
-    
+
     if (!$delete) {
       $form['ipv4'][$ids[0]]['subnet'][$ids[1]]['iid']['#options'] = $device_interfaces;
       $form['ipv4'][$ids[0]]['subnet'][$ids[1]]['did']['#value'] = guifi_get_devicename($device[0],'large');
@@ -291,7 +291,7 @@ function guifi_ahah_select_device_interfacename($delete = false) {
       $form['ipv4'][$ids[0]]['subnet'][$ids[1]]['deletedmsg']= array(
         '#type'=>'item',
         '#value'=>t('Address %addr will be DELETED',array('%addr'=>$_POST['ipv4'][$ids[0]]['subnet'][$ids[1]]['ipv4']))
-      );      
+      );
       drupal_set_message(t('Press "Reset" to discard changes.'),'warning');
     }
 
@@ -338,13 +338,13 @@ function guifi_ahah_select_device_subnets() {
     $ips = _ipcalc($difs->ipv4,$difs->netmask);
     $newip = guifi_ipcalc_find_ip($ips['netid'],$difs->netmask,$ips_allocated,false);
     if ($newip)
-      $device_snets[$newip.'|'.$difs->netmask.'|'.$difs->ipv4_type] = 
+      $device_snets[$newip.'|'.$difs->netmask.'|'.$difs->ipv4_type] =
         $newip.' '. t('from').' '.
         $ips[netid].'/'.$ips['maskbits'].' - '.$difs->interface_type;
     else {
       if ($difs->ipv4_type == 'public')
         drupal_set_message(t('Network %net/%mask at %int is full',
-          array('%net'  => $ips['netid'], 
+          array('%net'  => $ips['netid'],
                 '%mask' => $ips['maskbits'],
                 '%int'  => $difs->interface_type,
                )),
@@ -356,10 +356,10 @@ function guifi_ahah_select_device_subnets() {
     $form = $cache->data;
 
     $form['ipv4']['ipv4sdialog']['adddid']['#value'] = $dname;
-    
+
     $form['ipv4']['ipv4sdialog']['snet']['#options'] = $device_snets;
     $form['ipv4']['ipv4sdialog']['snet']['#type'] = 'select';
-    $form['ipv4']['ipv4sdialog']['snet']['#description'] = 
+    $form['ipv4']['ipv4sdialog']['snet']['#description'] =
       t('choose an address obtained from').':<br>'.
       $dname;
     cache_set($cid, $form, 'cache_form', $cache->expire);
@@ -546,18 +546,18 @@ function guifi_ahah_edit_cableconn() {
 function guifi_ahah_edit_subnet() {
   $cid = 'form_'. $_POST['form_build_id'];
   $cache = cache_get($cid, 'cache_form');
-  
+
   $SNet = arg(3);
   $ipv4 = $_POST['ipv4'][$SNet];
-/*  
+/*
   // $tree = array('ipv4',$SNetId);
   guifi_log(GUIFILOG_TRACE,sprintf('guifi_ahah_edit_subnet (id=%d):',$SNet),$ipv4);
-  
+
   if ($cache) {
     $form = $cache->data;
-  
+
     // Render the new output.
-    unset($form[ipv4][$SNet][subnet]['#prefix'], 
+    unset($form[ipv4][$SNet][subnet]['#prefix'],
       $form[ipv4][$SNet][subnet]['#suffix'], // Prevent duplicate wrappers.
       $form[ipv4][$SNet][subnet][$delta]);
     cache_set($cid, $form, 'cache_form', $cache->expire);
@@ -577,8 +577,8 @@ function guifi_ahah_edit_subnet() {
   drupal_json(array('status' => TRUE, 'data' => $output));
   }
   exit;
-*/  
-  
+*/
+
 
   // Build our new form element.
   $form_element =
@@ -600,11 +600,11 @@ function guifi_ahah_edit_subnet() {
   );
 
   // Rebuild the old form.
-  
+
   $form = form_builder('guifi_device_form', $form, $form_state);
   //if ($cache) {
   //  $form = $cache->data;
-  
+
   // Render the new output.
   $choice_form = $form[ipv4][$SNet][subnet];
   unset($choice_form['#post']);
@@ -623,7 +623,7 @@ function guifi_ahah_edit_subnet() {
     $newfield;
 
   drupal_json(array('status' => TRUE, 'data' => $output));
-  
+
   exit;
 
 }
@@ -639,19 +639,19 @@ function guifi_ahah_add_remoteipv4() {
   $deletedPresent = false;
   $ips = array(ip2long($ipv4[ipv4]));
   foreach ($ipv4[subnet] as $ki=>$i) {
-    if ($ki != 'add-ipv4') 
-      if ($i['deleted']==true) 
+    if ($ki != 'add-ipv4')
+      if ($i['deleted']==true)
         $deletedPresent = true;
-        
-    if (empty($i[ipv4]) and !(empty($i[ipv4value]))) 
+
+    if (empty($i[ipv4]) and !(empty($i[ipv4value])))
       $ipv4[subnet][$ki][ipv4]=$i[ipv4]=$i[ipv4value];
     if ($ip = ip2long($i[ipv4]))
       if (!in_array($ip,$ips))
        $ips[] = $ip;
   }
-       
+
   sort($ips);
-  
+
   guifi_log(GUIFILOG_BASIC,sprintf('guifi_ahah_add_remoteipv4 (id=%d):',$SNet),$ips);
     $ipc = _ipcalc($ipv4[ipv4],$ipv4[netmask]);
   $lstart = ip2long($ipc[netstart]);
@@ -1029,7 +1029,7 @@ function guifi_ahah_add_interface() {
  * Add ipv4s dialog
  * Used at device/radio edit form, at IPv4 Networking section for adding
  *  Public, Private subnetworks, or get an IP from an already defined subnetwork
- *  at another device 
+ *  at another device
  *
  * URL: http://guifi.net/guifi/js/add-ipv4s
  */
@@ -1039,12 +1039,12 @@ function guifi_ahah_add_ipv4s() {
 
   $iClass = arg(3);
   guifi_log(GUIFILOG_TRACE,'guifi_ahah_add_ipv4s('.$iClass.')',$_POST[ipv4][ipv4sdialog][netmask]);
-  
+
   //if (!$net) {
   //  drupal_set_message(t(
   //    'Unable to allocate new range, no networks available'),'warning');
   //  return FALSE;
-  //}  
+  //}
 
   if ($cache) {
     $form = $cache->data;
@@ -1059,18 +1059,18 @@ function guifi_ahah_add_ipv4s() {
     switch ($iClass) {
       case 'private':
         $form['ipv4']['ipv4sdialog']['adddid']['#type'] = 'hidden';
-        $form['ipv4']['ipv4sdialog']['adddid']['#value'] = false;        
+        $form['ipv4']['ipv4sdialog']['adddid']['#value'] = false;
         $form['ipv4']['ipv4sdialog']['snet']['#type'] = 'hidden';
         $form['ipv4']['ipv4sdialog']['snet']['#value'] = false;
         $form['ipv4']['ipv4sdialog']['netmask']['#type'] = 'select';
         $form['ipv4']['ipv4sdialog']['netmask']['#value'] = '255.255.255.252';
         $form['ipv4']['ipv4sdialog']['ipv4_type']['#value'] = 2;
         $form['ipv4']['ipv4sdialog']['ipv4']['#type'] = 'textfield';
-        $form['ipv4']['ipv4sdialog']['netmask']['#options'] = 
+        $form['ipv4']['ipv4sdialog']['netmask']['#options'] =
           guifi_types('netmask',30,26);
-        $form['ipv4']['ipv4sdialog']['netmask']['#description'] = 
+        $form['ipv4']['ipv4sdialog']['netmask']['#description'] =
           t('%class subnetwork size (mask)', array('%class'=>$iClass));
-        $form['ipv4']['ipv4sdialog']['#description'] = 
+        $form['ipv4']['ipv4sdialog']['#description'] =
           t('Obtain a new %class subnetwork range and get an IPv4 address from it',
                    array('%class'=>$iClass));
         break;
@@ -1083,17 +1083,17 @@ function guifi_ahah_add_ipv4s() {
         $form['ipv4']['ipv4sdialog']['netmask']['#value'] = '255.255.255.224';
         $form['ipv4']['ipv4sdialog']['ipv4_type']['#value'] = 1;
         $form['ipv4']['ipv4sdialog']['ipv4']['#type'] = 'textfield';
-        $form['ipv4']['ipv4sdialog']['netmask']['#options'] = 
+        $form['ipv4']['ipv4sdialog']['netmask']['#options'] =
           guifi_types('netmask',30,22);
-        $form['ipv4']['ipv4sdialog']['netmask']['#description'] = 
+        $form['ipv4']['ipv4sdialog']['netmask']['#description'] =
           t('%class subnetwork size (mask)',
-           array('%class'=>$iClass)); 
-        $form['ipv4']['ipv4sdialog']['#description'] = 
+           array('%class'=>$iClass));
+        $form['ipv4']['ipv4sdialog']['#description'] =
           t('Obtain a new %class subnetwork range and get an IPv4 address from it',
                    array('%class'=>$iClass));
         break;
       case 'netmask':
-        $form['ipv4']['ipv4sdialog']['netmask']['#value'] = 
+        $form['ipv4']['ipv4sdialog']['netmask']['#value'] =
           $_POST[ipv4][ipv4sdialog][netmask];
         break;
       case 'defined':
@@ -1102,12 +1102,12 @@ function guifi_ahah_add_ipv4s() {
         $form['ipv4']['ipv4sdialog']['snet']['#type'] = 'select';
         $form['ipv4']['ipv4sdialog']['ipv4']['#type'] = 'hidden';
         $form['ipv4']['ipv4sdialog']['ipv4']['#value'] = 'false';
-        $form['ipv4']['ipv4sdialog']['#description'] = 
+        $form['ipv4']['ipv4sdialog']['#description'] =
           t('Get a new ip from an already defined subnetwork range at any existing device');
     }
     // Obtaining ipv4
     if ($iClass != 'defined') {
-      $ntype = $form['ipv4']['ipv4sdialog']['ipv4_type']['#value']; 
+      $ntype = $form['ipv4']['ipv4sdialog']['ipv4_type']['#value'];
       drupal_set_message(t('Obtaining a new %type range',
         array('%type'  => ($ntype==1) ? t('public') : t('private'))),
         'warning');
@@ -1116,11 +1116,11 @@ function guifi_ahah_add_ipv4s() {
         $_POST[nid],
         $form['ipv4']['ipv4sdialog']['netmask']['#value'],
         ($ntype == 1) ? 'public' : 'backbone',
-        $ips_allocated, 'Yes', TRUE); 
-      $form['ipv4']['ipv4sdialog']['ipv4']['#value'] = 
+        $ips_allocated, 'Yes', TRUE);
+      $form['ipv4']['ipv4sdialog']['ipv4']['#value'] =
         long2ip(ip2long($net) + 1);
     }
-                    
+
 
     unset($form['ipv4']['ipv4sdialog']['#prefix']);
     unset($form['ipv4']['ipv4sdialog']['#suffix']);
@@ -1194,7 +1194,7 @@ function guifi_ahah_add_vinterface($iClass) {
   $newI['id'] = $delta;
   $newI['interface_id'] = $delta;
   $edit[$iClass][] = $newI;
-  
+
 
   foreach ($edit[$iClass] as $k => $value) {
     guifi_log(GUIFILOG_TRACE,'guifi_ahah_add_vinterface(iname)',$value);
@@ -1204,7 +1204,7 @@ function guifi_ahah_add_vinterface($iClass) {
   guifi_log(GUIFILOG_TRACE,'guifi_ahah_add_vinterface(newI)',$newI);
 
   $form_element =
-    guifi_vinterfaces_form($iClass,$edit);  
+    guifi_vinterfaces_form($iClass,$edit);
 //    guifi_vinterface_form($iClass,$newI,!$delta,guifi_get_currentInterfaces($_POST));
 //  drupal_alter('form', $form_element, array(), 'guifi_ahah_add_interface');
 
@@ -1247,7 +1247,7 @@ function guifi_ahah_add_vinterface($iClass) {
 }
 
 /**
- * Select firmware by model
+ * Select firmware by model for Drupal 6
  *
  * URL: http://guifi.net/guifi/js/firmware_by_model
  */
@@ -1285,6 +1285,16 @@ function guifi_ahah_select_firmware_by_model(){
   }
   exit;
 }
+
+/**
+ * Select firmware by model for Drupal 7
+ *
+ * URL: http://guifi.net/guifi/js/firmware_by_model
+ */
+function guifi7_ahah_select_firmware_by_model($form, &$form_state){
+  return $form['radio_settings']['variable']['firmware_id'];
+}
+
 
 /**
  * Select channel by protocol

--- a/guifi_radios.inc.php
+++ b/guifi_radios.inc.php
@@ -39,25 +39,42 @@ function guifi_radio_form($edit, $form_weight) {
   // '#default_value' => $edit['mid'],
   $form['radio_settings']['variable']['model_id'] = array(
     '#type' => 'select',
-    '#title' => t("Radio Model"),
+    '#title' => t("Device model"),
     '#required' => TRUE,
      '#default_value' => $edit['variable']['model_id'],
     '#options' => $models_array,
-    '#description' => t('Select the radio model that do you have.'),
-    '#prefix' => '<table><tr><td>',
-    '#suffix' => '</td>',
+    '#description' => t('Select the manufacturer and model of your device.'),
     '#ajax' => array(
-      'path' => 'guifi/js/firmware_by_model',
+      'callback' => 'guifi7_ahah_select_firmware_by_model',
       'wrapper' => 'select-firmware',
       'method' => 'replace',
       'effect' => 'fade',
      ),
-    '#weight' => 0,
+    '#weight' => 1,
   );
 
-  $form['radio_settings']['variable']['firmware_id'] =
-  guifi_radio_firmware_field($edit['variable']['firmware_id'],
-      $edit['variable']['model_id']);
+  $fid = $edit['variable']['firmware_id'];
+
+  $options = array();
+  $firm = guifi_types('firmware', NULL, NULL,$edit['variable']['model_id']);
+
+  foreach( $firm as $key => $i) {
+    $options[$firm[$key]['fid']] = t($firm[$key]['description']);
+  }
+
+  $form['radio_settings']['variable']['firmware_id'] = array(
+    '#type' => 'select',
+    '#title' => t('Firmware'),
+    '#parents' => array('variable','firmware_id'),
+    '#required' => TRUE,
+    '#default_value' => $fid,
+    '#prefix' => '<div id="select-firmware">',
+    '#suffix' => '</div>',
+    '#options' => $options,
+    '#description' => t('Select the firmware version used by your device. This is used for automatic configuration.'),
+    '#weight' => 2,
+  );
+
 
   $form['radio_settings']['variable']['firmware'] = array(
     '#type' => 'hidden',
@@ -66,16 +83,14 @@ function guifi_radio_form($edit, $form_weight) {
 
   $form['radio_settings']['mac'] = array(
     '#type' => 'textfield',
-    '#title' => t('Device MAC Address'),
+    '#title' => t('Primary MAC address'),
     '#required' => TRUE,
     '#size' => 20,
     '#maxlength' => 20,
     '#default_value' => $edit['mac'],
     '#element_validate' => array('guifi_mac_validate'),
-    '#description' => t("Base/Main MAC Address.<br />Some configurations won't work if is blank"),
-    '#prefix' => '<td>',
-    '#suffix' => '</td></tr></table>',
-    '#weight' => 4
+    '#description' => t("Write the primary MAC Address of your device in the 00:11:22:33:aa:bb format. Usually it is the MAC address of the first Ethernet interface (e.g. eth0)."),
+    '#weight' => 3
   );
 
   $collapse = TRUE;
@@ -308,6 +323,7 @@ function guifi_radio_add_radio_form($edit) {
 }
 
 function guifi_radio_firmware_field($fid,$mid) {
+//En desús a partir de Drupal 7
 /* Consulta anterior al  PFC */
   $model = db_query(
         "SELECT model as name, mid as id " .
@@ -317,20 +333,21 @@ function guifi_radio_firmware_field($fid,$mid) {
 
   $options = array();
   $firm = guifi_types('firmware', NULL, NULL,$model->id);
+
   foreach( $firm as $key => $i) {
     $options[$firm[$key]['fid']] = t($firm[$key]['description']);
   }
 
   return array(
     '#type' => 'select',
-    '#title' => t("Firmware"),
-    '#parents' => array('variable','firmware_id'),
+    '#title' => t('Firmware'),
+    //'#parents' => array('variable','firmware_id'),
     '#required' => TRUE,
     '#default_value' => $fid,
-    '#prefix' => '<td><div id="select-firmware">',
-    '#suffix' => '</div></td>',
+    '#prefix' => '<div id="select-firmware">',
+    '#suffix' => '</div>',
     '#options' => $options,
-    '#description' => t('Used for automatic configuration.'),
+    '#description' => t('Select the firmware version used by your device. This is used for automatic configuration.'),
     '#weight' => 2,
   );
 }


### PR DESCRIPTION
This commit deprecates the guifi_radio_firmware_field() and guifi_ahah_select_firmware_by_model() functions, since the dynamic update of the firmware field is now managed by Drupal 7.
