### PR TITLE
Fix or improve some functionalities before actually adding full support for hybrid-nodes

### DIFF
--- a/guifi.install
+++ b/guifi.install
@@ -165,7 +165,8 @@ function guifi_schema() {
          'ipv4_id' => array('type' => 'int', 'size' => 'tiny', 'not null' => TRUE),
          'link_type' => array('type' => 'varchar', 'length' => '40', 'not null' => TRUE),
          'routing' => array('type' => 'varchar', 'length' => '40', 'not null' => FALSE),
-         'flag' => array('type' => 'varchar', 'length' => '40', 'not null' => TRUE, 'default' => 'Planned')),
+         'flag' => array('type' => 'varchar', 'length' => '40', 'not null' => TRUE, 'default' => 'Planned'),
+         'hybrid' => array('type' => 'int', 'size' => 'tiny', 'not null' => TRUE, 'default' => 0)),
     'primary key' => array('device_id', 'id'),
     'indexes' => array(
          'id' => array('id'),
@@ -3369,5 +3370,17 @@ function guifi_update_1043() {
   return $items;
 }
 
+function guifi_update_1046() {
+
+  $items = array();
+
+  $items[] = update_sql("ALTER TABLE {guifi_links} " .
+    "ADD COLUMN hybrid BOOLEAN NOT NULL DEFAULT '0' AFTER flag");
+
+  $items[] = update_sql("UPDATE {guifi_links} SET hybrid = FALSE");
+
+  return $items;
+
+}
 
 ?>

--- a/guifi_devices.inc.php
+++ b/guifi_devices.inc.php
@@ -72,7 +72,7 @@ function guifi_device_load($id,$ret = 'array') {
         OR (interface_class = "bridge")
         OR (interface_class = "vlan")
       )
-    ORDER BY etherdev_counter, id',
+    ORDER BY interface_class, etherdev_counter, id',
     $id);
 
   while ($i = db_fetch_array($qi)) {

--- a/guifi_devices.inc.php
+++ b/guifi_devices.inc.php
@@ -69,11 +69,8 @@ function guifi_device_load($id,$ret = 'array') {
         (interface_class is NULL AND ( interface_type NOT IN ("wLan","wds/p2p","Wan","Hotspot")))
         /* schema v2 */
         OR (interface_class = "ethernet")
-        /* TODO HACK!!
-            Permetem temporalment fer enllaços per cable a interficies bridge
-            OJO! afecta al comptador de ports quan es crea el switch dins un trasto, s\'ha de corregir.
-        */
         OR (interface_class = "bridge")
+        OR (interface_class = "vlan")
       )
     ORDER BY etherdev_counter, id',
     $id);

--- a/guifi_includes.inc.php
+++ b/guifi_includes.inc.php
@@ -549,7 +549,7 @@ function guifi_get_device_interfaces($id,$iid = NULL, $used = NULL) {
     WHERE device_id = ' .$did[0];
 
   $sql_i .=
-    ' AND ( interface_class = "ethernet" OR
+    ' AND ( interface_class = "ethernet" OR interface_class = "vlan" OR interface_class = "bridge" OR
       ( interface_class is NULL AND (radiodev_counter is NULL OR upper(interface_type) IN ("WLAN/LAN"))))';
 
   guifi_log(GUIFILOG_TRACE,'guifi_get_devicename(sql)',$sql_i);

--- a/guifi_interfaces.inc.php
+++ b/guifi_interfaces.inc.php
@@ -33,7 +33,7 @@ function guifi_interfaces_form(&$interface,$ptree) {
 
   $f['interface'] = guifi_form_hidden_var(
     $interface,
-    array('id','interface_type','radiodev_counter'),
+    array('id','interface_type','radiodev_counter', 'interface_class'),
     $ptree
   );
 

--- a/guifi_switch.inc.php
+++ b/guifi_switch.inc.php
@@ -78,6 +78,7 @@ function guifi_ports_form($edit,&$form_weight) {
   guifi_log(GUIFILOG_TRACE,'function guifi_ports_form(m)',$m);
 
   $port_count = 0;
+  $first_port = true;
   foreach ($edit['interfaces'] as $port => $interface) {
 
     guifi_log(GUIFILOG_TRACE,'function guifi_ports_form(interface)',$interface);
@@ -86,10 +87,13 @@ function guifi_ports_form($edit,&$form_weight) {
     // -with no interface type
     // -with related interfaces
     // -no interface_class but 'wLan/Lan' (v1 schema)
-    if (empty($interface['interface_type']) or
-       (!empty($interface[related_interfaces])) or
-       (empty($interface[interface_class]) and $interface[interface_type]=='wLan/Lan')
-       )
+    // -vlans
+    // -bridges
+    if (empty($interface['interface_type']) OR
+        !empty($interface[related_interfaces]) OR
+        (empty($interface[interface_class]) and $interface[interface_type]=='wLan/Lan') OR
+        $interface[interface_class] == 'vlan' OR
+        $interface[interface_class] == 'bridge' )
     {
       guifi_log(GUIFILOG_TRACE,'function guifi_ports_form(interface)',$interface);
       continue;
@@ -297,6 +301,16 @@ function guifi_ports_form($edit,&$form_weight) {
       $form[$port]['id'] = array(
         '#type'         => 'hidden',
         '#value'        => $interface['id'],
+        '#weight'       => $form_weight++,
+      );
+      $form[$port]['interface_class'] = array(
+        '#type'         => 'hidden',
+        '#value'        => $interface['interface_class'],
+        '#weight'       => $form_weight++,
+      );
+      $form[$port]['related_interfaces'] = array(
+        '#type'         => 'hidden',
+        '#value'        => $interface['related_interfaces'],
         '#weight'       => $form_weight++,
       );
       $form[$port]['device_id'] = array(
@@ -751,6 +765,16 @@ function guifi_vinterface_form($iClass, $vinterface, $first_port = true, $eInter
     $form['id'] = array(
       '#type'         => 'hidden',
       '#value'        => $vinterface['id'],
+    );
+    $form[$port]['interface_class'] = array(
+      '#type'         => 'hidden',
+      '#value'        => $interface['interface_class'],
+      '#weight'       => $form_weight++,
+    );
+    $form[$port]['related_interfaces'] = array(
+      '#type'         => 'hidden',
+      '#value'        => $interface['related_interfaces'],
+      '#weight'       => $form_weight++,
     );
     $form['device_id'] = array(
       '#type'         => 'hidden',

--- a/guifi_switch.inc.php
+++ b/guifi_switch.inc.php
@@ -67,17 +67,17 @@ function guifi_ports_form($edit,&$form_weight) {
   if ($swmodel->opto_interfaces)
     $connector_types = array_merge($connector_types, guifi_types('fo_port'));
 
-  // Loop across all existing interfaces
-  $port_count = 0;
-  $total_ports = count($edit['interfaces']);
-  $first_port = true;
+  // Initialize the Ethernet port count array by looping across all interfaces
+  // and counting only those of class "ethernet" (no vlans, bridges, etc.)
   $eCountOpts = array();
-  for ($i = 0; $i < $total_ports; $i++)
-  	$eCountOpts[$i] = $i;
+  foreach ($edit['interfaces'] as $key => $value)
+    if ($value['interface_class'] == 'ethernet')
+      $eCountOpts[count($eCountOpts)] = count($eCountOpts);
 
   $m = guifi_get_model_specs($edit[variable][model_id]);
   guifi_log(GUIFILOG_TRACE,'function guifi_ports_form(m)',$m);
 
+  $port_count = 0;
   foreach ($edit['interfaces'] as $port => $interface) {
 
     guifi_log(GUIFILOG_TRACE,'function guifi_ports_form(interface)',$interface);


### PR DESCRIPTION
[En català més avall]

This patchset fixes or improves some functionalities needed before fully supporting hybrid nodes. Namely:

**d2f06c1d6fb7cefa6623e322061e1dfde529ec82: Add hybrid nodes support in guifi_links table schema**
Add a new field in the guifi_links table schema to specify whether a link between devices is part of a hybrid node.

**2e684aada1e2ef16d60f61764f86c1d481279963: allow creating links between ethernet, bridge and vlan interfaces**
This feature was partially supported in some places of the code, now it is fully available. This way clients can get an IP address from another device that has the network prefix assigned to a bridge, for instance.

**a671985bf7d84049f45969111365f6b8949007e4: Fix #32 - Virtual interfaces (bridges, vlans, etc.) are counted as physical ports**
In the "Ports" section, non-physical interfaces (e.g. brigdes and vlans) were being processed when they should not. Now they aren't.

**a54f93343fc23fe242259aa94154ca124e7ac254: Fix #31 - Cable networking section does not show vlan interfaces**
"vlan"-class interfaces are now shown under the interfaces section, where "bridge" interfaces were already along "ethernet" ones.

**c7f8e67acaa38f41ce0d23e2cf62d88fb9718e18: sort interfaces list by interface class, then by etherdev_counter, then by id**
Just a minor usability enhancement.

**835f286aca122200e979c5dc530fee092d1a2895: Fix #33 - When deleting a network prefix from an interface, non-physical interfaces appear in the ports section**
In some parts of the device form, some fields of non-"ethernet" classed interfaces were not being saved when submitting the form, which led to an incoherent "Ports" section in some special occasions (e.g. when deleting an IPv4 prefix).

#

Aquest conjunt de pedaços arregla o millora algunes funcionalitats requerides abans de donar suport complet als nodes híbrids. A saber:

**d2f06c1d6fb7cefa6623e322061e1dfde529ec82: Add hybrid nodes support in guifi_links table schema**
Afegeix un nou camp a la l'_schema_ de la taula guifi_links per especificar si un enllaç entre trastos és part d'un node híbrid.

**2e684aada1e2ef16d60f61764f86c1d481279963: allow creating links between ethernet, bridge and vlan interfaces**
Aquesta funcionalitat estava parcialment suportada en algunes parts del codi; ara ho està arreu. Així, els clients poden obtenir una adreça IP des d'un altre trasto que tingui el prefix de xarxa assignat a un _bridge_, per exemple.

**a671985bf7d84049f45969111365f6b8949007e4: Fix #32 - Virtual interfaces (bridges, vlans, etc.) are counted as physical ports**
A la secció "Ports", les interfícies virtuals (p.ex. _bridges_ i _vlans_) es llistaven tot i que no hi tocava. Ara ja no s'hi llisten.

**a54f93343fc23fe242259aa94154ca124e7ac254: Fix #31 - Cable networking section does not show vlan interfaces**
Les interfícies de classe "vlan" ara es mostren dins la secció d'interfícies, on ja hi eren les de classe _bridge_ així com les "ethernet".

**c7f8e67acaa38f41ce0d23e2cf62d88fb9718e18: sort interfaces list by interface class, then by etherdev_counter, then by id**
Una petita millora en la usabilitat.

**835f286aca122200e979c5dc530fee092d1a2895: Fix #33 - When deleting a network prefix from an interface, non-physical interfaces appear in the ports section**
En algunes parts del formulari d'un trasto, alguns camps d'interfícies de classe no-"ethernet" no s'estaven enviant a l'hora de desar el formulari, cosa que generava incoherències a la secció "Ports" en determinats casos (p.ex. a l'hora d'esborrar un prefix IPv4).